### PR TITLE
Increase django version to 2.2.24

### DIFF
--- a/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__line-endings-constraints-a.txt.snap
+++ b/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__line-endings-constraints-a.txt.snap
@@ -46,7 +46,7 @@ RequirementsTxt {
                         [
                             VersionSpecifier {
                                 operator: Equal,
-                                version: "2.2.10",
+                                version: "2.2.24",
                             },
                         ],
                     ),

--- a/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__line-endings-constraints-b.txt.snap
+++ b/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__line-endings-constraints-b.txt.snap
@@ -17,7 +17,7 @@ RequirementsTxt {
                                 [
                                     VersionSpecifier {
                                         operator: Equal,
-                                        version: "2.2.10",
+                                        version: "2.2.24",
                                     },
                                 ],
                             ),

--- a/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__parse-constraints-a.txt.snap
+++ b/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__parse-constraints-a.txt.snap
@@ -46,7 +46,7 @@ RequirementsTxt {
                         [
                             VersionSpecifier {
                                 operator: Equal,
-                                version: "2.2.10",
+                                version: "2.2.24",
                             },
                         ],
                     ),

--- a/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__parse-constraints-b.txt.snap
+++ b/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__parse-constraints-b.txt.snap
@@ -17,7 +17,7 @@ RequirementsTxt {
                                 [
                                     VersionSpecifier {
                                         operator: Equal,
-                                        version: "2.2.10",
+                                        version: "2.2.24",
                                     },
                                 ],
                             ),

--- a/crates/uv-requirements-txt/test-data/requirements-txt/constraints-b.txt
+++ b/crates/uv-requirements-txt/test-data/requirements-txt/constraints-b.txt
@@ -1,6 +1,6 @@
 # django==2.1.15
 # django needs to be at least 2.2.10 or it contains a critical SQL injection vulnerability.
 # current version of django is 4.2.16
-django==2.2.10
+django==2.2.24
 
 pytz==2023.3


### PR DESCRIPTION
django < 2.2.24 vulnerable to access control bypass possibly leading to SSRF, RFI, and LFI attacks
